### PR TITLE
Remove hard coded google STUN servers - redeploy

### DIFF
--- a/front/src/WebRtc/ScreenSharingPeer.ts
+++ b/front/src/WebRtc/ScreenSharingPeer.ts
@@ -24,9 +24,6 @@ export class ScreenSharingPeer extends Peer {
             config: {
                 iceServers: [
                     {
-                        urls: 'stun:stun.l.google.com:19302'
-                    },
-                    {
                         urls: TURN_SERVER.split(','),
                         username: TURN_USER,
                         credential: TURN_PASSWORD

--- a/front/src/WebRtc/VideoPeer.ts
+++ b/front/src/WebRtc/VideoPeer.ts
@@ -21,9 +21,6 @@ export class VideoPeer extends Peer {
             config: {
                 iceServers: [
                     {
-                        urls: 'stun:stun.l.google.com:19302'
-                    },
-                    {
                         urls: TURN_SERVER.split(','),
                         username: TURN_USER,
                         credential: TURN_PASSWORD
@@ -37,9 +34,6 @@ export class VideoPeer extends Peer {
             reconnectTimer: 10000,
             config: {
                 iceServers: [
-                    {
-                        urls: 'stun:stun.l.google.com:19302'
-                    },
                     {
                         urls: TURN_SERVER.split(','),
                         username: TURN_USER,


### PR DESCRIPTION
Instead just use the configured TURN servers.
Origin: https://gitlab.hasi.it/herzi/project/workadventure/-/commit/5d7192567e3775c69db0886c40c2c4416325edb8

Refs: #2